### PR TITLE
Cleanups for JSHint

### DIFF
--- a/demo/unit1-fps.js
+++ b/demo/unit1-fps.js
@@ -3,10 +3,10 @@
 // Use the slider to adjust FPS an see how that changes the responsiveness    //
 // of the scene.                                                              //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE*/
 
-/*global THREE, requestAnimationFrame, Detector, Stats, dat */
-var container, camera, scene, renderer, stats;
+/*global THREE, requestAnimationFrame, Stats, dat */
+
+var camera, scene, renderer, stats;
 var cameraControls;
 var effectController;
 var clock = new THREE.Clock();
@@ -15,10 +15,11 @@ var ambientLight, light, light2;
 var teapot;
 var newTime = 0, oldTime = 0;
 
+var canvasWidth, canvasHeight;
 
 function init() {
-	var canvasWidth = window.innerWidth;
-	var canvasHeight = window.innerHeight;
+	canvasWidth = window.innerWidth;
+	canvasHeight = window.innerHeight;
 	var canvasRatio = canvasWidth / canvasHeight;
 	// CAMERA
 
@@ -28,8 +29,6 @@ function init() {
 	// SCENE
 
 	scene = new THREE.Scene();
-
-	scene.add( camera );
 
 	// LIGHTS
 
@@ -109,8 +108,8 @@ function init() {
 
 function onWindowResize() {
 
-	SCREEN_WIDTH = canvasWidth;
-	SCREEN_HEIGHT = canvasHeight;
+	var SCREEN_WIDTH = canvasWidth;
+	var SCREEN_HEIGHT = canvasHeight;
 
 	renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 
@@ -184,8 +183,3 @@ function render() {
 
 init();
 animate();
-$("body").keydown(function(event) {
-	if (event.which === 80) {
-		takeScreenshot();
-	}
-});

--- a/demo/unit1-teacup-demo.js
+++ b/demo/unit1-teacup-demo.js
@@ -277,8 +277,6 @@ function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
 
-	scene.add( camera );
-
 	// LIGHTS
 
 	scene.add( ambientLight );

--- a/demo/unit1-teapot-demo.js
+++ b/demo/unit1-teapot-demo.js
@@ -211,7 +211,7 @@ function render() {
 		effectController.body !== bBody ||
 		effectController.fitLid !== bFitLid ||
 		effectController.nonblinn !== bNonBlinn ||
-	    effectController.newFlat !== flat || effectController.newPhong !== phong || effectController.newWire !== wire)
+		effectController.newFlat !== flat || effectController.newPhong !== phong || effectController.newWire !== wire)
 	{
 		tess = effectController.newTess;
 		bBottom = effectController.bottom;
@@ -290,8 +290,6 @@ function createShaderMaterial( id, light, ambientLight ) {
 function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
-
-	scene.add( camera );
 
 	// LIGHTS
 

--- a/demo/unit1-teaspoon-demo.js
+++ b/demo/unit1-teaspoon-demo.js
@@ -265,8 +265,6 @@ function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
 
-	scene.add( camera );
-
 	// LIGHTS
 
 	scene.add( ambientLight );

--- a/demo/unit2-z-fighting.js
+++ b/demo/unit2-z-fighting.js
@@ -2,10 +2,9 @@
 // Drinking Bird Model exercise                                               //
 // Your task is to complete the model for the drinking bird                   //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE*/
+/*global THREE, $, Coordinates, requestAnimationFrame*/
 
 var camera, scene, renderer;
-var windowScale;
 var cameraControls;
 var clock = new THREE.Clock();
 function drawDrinkingBird() {
@@ -63,7 +62,7 @@ function drawDrinkingBird() {
 	scene.add( cube );
 	
 	// body
-	var sphere = new THREE.Mesh(
+	sphere = new THREE.Mesh(
 		new THREE.SphereGeometry( 116/2, 32, 16 ), sphereMaterial );
 	sphere.position.x = 0;
 	sphere.position.y = 160;
@@ -71,7 +70,7 @@ function drawDrinkingBird() {
 	scene.add( sphere );
 
 	// head
-	var sphere = new THREE.Mesh(
+	sphere = new THREE.Mesh(
 		new THREE.SphereGeometry( 104/2, 32, 16 ), sphereMaterial );
 	sphere.position.x = 0;
 	sphere.position.y = 160 + 390;
@@ -79,7 +78,7 @@ function drawDrinkingBird() {
 	scene.add( sphere );
 
 	// head/body connector
-	var cylinder = new THREE.Mesh( 
+	cylinder = new THREE.Mesh( 
 		new THREE.CylinderGeometry( 24/2, 24/2, 390, 32 ), cylinderMaterial );
 	cylinder.position.x = 0;
 	cylinder.position.y = 160 + 390/2;
@@ -87,7 +86,7 @@ function drawDrinkingBird() {
 	scene.add( cylinder );
 	
 	// hat brim
-	var cylinder = new THREE.Mesh( 
+	cylinder = new THREE.Mesh( 
 		new THREE.CylinderGeometry( 142/2, 142/2, 10, 32 ), cylinderMaterial );
 	cylinder.position.x = 0;
 	cylinder.position.y = 160 + 390 + 40 + 10/2;
@@ -95,16 +94,12 @@ function drawDrinkingBird() {
 	scene.add( cylinder );
 	
 	// hat top
-	var cylinder = new THREE.Mesh( 
+	cylinder = new THREE.Mesh( 
 		new THREE.CylinderGeometry( 80/2, 80/2, 70, 32 ), cylinderMaterial );
 	cylinder.position.x = 0;
 	cylinder.position.y = 160 + 390 + 40 + 10 + 70/2;
 	cylinder.position.z = 0;
 	scene.add( cylinder );
-}
-
-var controls = {
-	painters: false,
 }
 
 function init() {
@@ -120,7 +115,7 @@ function init() {
 	light.position.set( 200, 400, 500 );
 	scene.add( light );
 	
-	var light = new THREE.DirectionalLight( 0xffffff, 1.0 );
+	light = new THREE.DirectionalLight( 0xffffff, 1.0 );
 	light.position.set( -400, 200, -300 );
 	scene.add( light );
 
@@ -172,12 +167,12 @@ function takeScreenshot() {
 	camera.position.set( 400, 500, -800 );
 	render();
 	var img2 = renderer.domElement.toDataURL("image/png");
-	imgTarget = window.open('', 'For grading script');
+	var imgTarget = window.open('', 'For grading script');
 	imgTarget.document.write('<img src="'+img1+'"/><img src="'+img2+'"/>');
 }
 
 init();
-drinkingBird = drawDrinkingBird();
+var drinkingBird = drawDrinkingBird();
 scene.add(drinkingBird);
 animate();
 $("body").keydown(function(event) {

--- a/demo/unit3-blending.js
+++ b/demo/unit3-blending.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit3-color-demo.js
+++ b/demo/unit3-color-demo.js
@@ -1,9 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////////
-// RGB color demo  (unit 3)                                                   //
+// RGB additive color demo  (unit 3)                                                   //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE*/
 
 /*global THREE, requestAnimationFrame, dat, window, document*/
+
 var camera, scene, renderer;
 var cameraControls;
 var ec;
@@ -17,38 +17,38 @@ var intensityBlue = 1;
 function init() {
 	var canvasWidth = window.innerWidth;
 	var canvasHeight = window.innerHeight;
-	var canvasRatio = canvasWidth / canvasHeight;
 
 	// CAMERA
-	camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 80000 );
+	camera = new THREE.PerspectiveCamera( 34, window.innerWidth / window.innerHeight, 1, 80000 );
 	camera.position.set( 0, 0, 400 );
 
+	var overlap = 1.3;
 	light1 = new THREE.SpotLight();
 	light1.color.setRGB(intensityRed, 0, 0);
-	light1.position.set( 0, 75, 100 );
-	light1.angle = 0.7;
+	light1.position.set( 0, 50/overlap, 1000 );
+	light1.angle = 0.08;
 	light1.exponent = 0;
-	light1.target.position.set( 0, 75, 0 );
+	light1.target.position.set( 0, 50/overlap, 0 );
 
 	light2 = new THREE.SpotLight();
 	light2.color.setRGB(0, intensityGreen, 0);
-	light2.position.set( -61, -25, 100 );
+	light2.position.set( -61/overlap, -50/overlap, 1000 );
 	light2.exponent = 0;
-	light2.target.position.set( -61, -25, 0 );
-	light2.angle = 0.7;
+	light2.target.position.set( -61/overlap, -50/overlap, 0 );
+	light2.angle = 0.08;
 
 	light3 = new THREE.SpotLight();
 	light3.color.setRGB(0, 0, intensityBlue);
-	light3.position.set( 61, -25, 100 );
+	light3.position.set( 61/overlap, -50/overlap, 1000 );
 	light3.exponent = 0;
-	light3.target.position.set( 61, -25, 0 );
-	light3.angle = 0.7;
+	light3.target.position.set( 61/overlap, -50/overlap, 0 );
+	light3.angle = 0.08;
 
 	//  GROUND
 
-	var gg = new THREE.PlaneGeometry( 10000, 10000 );
-	var gm = new THREE.MeshPhongMaterial( { color: 0xffffff, side: THREE.DoubleSide } );
-	gm.specular.setRGB(0,0,0);
+	var gg = new THREE.PlaneGeometry( 270, 250, 2*270, 2*250 );
+	var gm = new THREE.MeshLambertMaterial( { color: 0xffffff, side: THREE.DoubleSide } );
+	//gm.specular.setRGB(0,0,0);
 
 	ground = new THREE.Mesh( gg, gm );
 
@@ -138,7 +138,7 @@ function render() {
 
 function fillScene() {
 	scene = new THREE.Scene();
-	scene.add( camera );
+
 	// LIGHTS
 
 	scene.add( light1 );

--- a/demo/unit3-diffuse-demo.js
+++ b/demo/unit3-diffuse-demo.js
@@ -1,12 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Teapot demo  (unit 3)                                                      //
-// per-pixel shading - up/down arrows for tessellation;                       //
-// 'F' for flat/smooth,                                                       //
-// 'V' for vertex/pixel shading.                                              //
+// Change angle of light to see how effect decreases with angle
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE*/
 
 /*global THREE, requestAnimationFrame, dat, window, document*/
+
 var camera, scene, renderer;
 var cameraControls;
 var ec;
@@ -98,10 +95,6 @@ function setupGui() {
 	var gui = new dat.GUI();
 	var element = gui.add( ec, "angle", 0.0, 90.0 ).step(0.1);
 	element.name("Light angle");
-	// element = gui.add( ec, "green", 0.0, 1.0 ).step(0.1);
-	// element.name("Green intensity");
-	// element = gui.add( ec, "blue", 0.0, 1.0 ).step(0.1);
-	// element.name("Blue intensity");
 }
 
 
@@ -131,16 +124,15 @@ function render() {
 
 function fillScene() {
 	scene = new THREE.Scene();
-	scene.add( camera );
-	// LIGHTS
 
+	// LIGHTS
 	scene.add( light1 );
 	scene.add( light2 );
 	scene.add( light3 );
+	
 	scene.add( ground );
 	scene.add(lightMesh);
 	//Coordinates.drawGrid({size:75,scale:0.1, orientation:"z"});
-
 
 }
 

--- a/demo/unit3-over_operator.js
+++ b/demo/unit3-over_operator.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit3-teapot-demo.js
+++ b/demo/unit3-teapot-demo.js
@@ -265,8 +265,6 @@ function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
 
-	scene.add( camera );
-
 	// LIGHTS
 
 	scene.add( ambientLight );

--- a/demo/unit3-tessellation-demo.js
+++ b/demo/unit3-tessellation-demo.js
@@ -1,8 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE, requestAnimationFrame, Detector, Stats, dat window document Coordinates*/
+/*global THREE, dat, window, document*/
+
 var camera, scene, renderer;
-var cameraControls;
+var cameraControls, effectController;
 var clock = new THREE.Clock();
 var ambientLight, light;
 var tess = 3;	// force initialization
@@ -12,7 +13,6 @@ var flat;
 function init() {
 	var canvasWidth = window.innerWidth;
 	var canvasHeight = window.innerHeight;
-	var canvasRatio = canvasWidth / canvasHeight;
 
 	// CAMERA
 
@@ -70,7 +70,6 @@ var material3 = new THREE.MeshLambertMaterial( { color: 0xFFFF00, wireframe: tru
 function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
-	//scene.add( camera );
 
 	// LIGHTS
 	scene.add( ambientLight );
@@ -96,10 +95,9 @@ function onWindowResize() {
 
 	renderer.setSize( canvasWidth, canvasHeight );
 
-	camera.aspect = canvasWidth/ canvasHeight;
+	camera.aspect = canvasWidth / canvasHeight;
 	camera.updateProjectionMatrix();
 }
-
 
 //
 
@@ -129,10 +127,4 @@ function render() {
 
 init();
 animate();
-
-
-
-
-
-
 

--- a/demo/unit3-transparency.js
+++ b/demo/unit3-transparency.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit4-euler_angles.js
+++ b/demo/unit4-euler_angles.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;
@@ -156,7 +156,7 @@ function setupGui() {
 		
 		ex: 0.0,
 		ey: 0.0,
-		ez: 0.0,
+		ez: 0.0
 	};
 
 	var gui = new dat.GUI();

--- a/demo/unit4-robot_arm_demo.js
+++ b/demo/unit4-robot_arm_demo.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit4-robot_arm_demo_forearm.js
+++ b/demo/unit4-robot_arm_demo_forearm.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit4-robot_arm_demo_upper_arm.js
+++ b/demo/unit4-robot_arm_demo_upper_arm.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/demo/unit4-rotate_then_scale.js
+++ b/demo/unit4-rotate_then_scale.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // NOTE: this is not really a demo, just a way to show what goes wrong with a bad order.
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 							     	<option value="?load=demo/unit3-diffuse-demo.js">Lesson 3 diffuse
 							     	<option value="?load=demo/unit3-over_operator.js">Lesson 3 Over operator
 							     	<option value="?load=demo/unit3-teapot-demo.js">Lesson 3 teapot
-							     	<option value="?load=demo/unit3-tessellation-demo.js">Lesson 3 tesselation
+							     	<option value="?load=demo/unit3-tessellation-demo.js">Lesson 3 tessellation
 							     	<option value="?load=demo/unit3-transparency.js">Lesson 3 transparency
 							     	<option value="?load=demo/unit4-euler_angles.js">Lesson 4 Euler angles
 							     	<option value="?load=demo/unit4-robot_arm_demo.js">Lesson 4 Robot arm

--- a/lib/Coordinates.js
+++ b/lib/Coordinates.js
@@ -1,4 +1,4 @@
-/*global THREE scene*/
+/*global THREE, scene*/
 var Coordinates = {
 	drawGrid:function(params) {
 		params = params || {};

--- a/lib/OrbitAndPanControls.js
+++ b/lib/OrbitAndPanControls.js
@@ -5,9 +5,9 @@
  * @author WestLangley / https://github.com/WestLangley
  * @author erich666 / http://erichaines.com
  *
- * Not quite correct: sort of assumes a 45 degree field of view.
- * Currently uses distance to target for offsetting
+ * TODO: finish touch controls so it can be used on smartphones.
  */
+/*global THREE */
 
 THREE.OrbitAndPanControls = function ( object, domElement ) {
 

--- a/lib/uclass_BeveledBlockGeometry.js
+++ b/lib/uclass_BeveledBlockGeometry.js
@@ -2,6 +2,8 @@
  * @author Eric Haines / http://erichaines.com/
  *
  * Make a block with beveled edges, to catch highlights.
+ *
+ * TODO: bug when bevel >= depth/2 (or width/2, or height/2)
  */
 /*global THREE */
 

--- a/unit1/fix-javascript-errors.js
+++ b/unit1/fix-javascript-errors.js
@@ -8,7 +8,7 @@
 // WebGL is not supported in Internet Explorer                                //
 // There are 4 syntax errors in this code                                     //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE Coordinates $ document window*/
+/*global THREE, Coordinates, $, document, window*/
 
 var camera, scene, renderer;
 var windowScale;

--- a/unit2/drinking-bird.js
+++ b/unit2/drinking-bird.js
@@ -4,7 +4,7 @@
 // Using the provided sizes and colors, complete the staircase                //
 // and reach the Gold Cup!                                                    //
 ////////////////////////////////////////////////////////////////////////////////
-/*global, THREE, Coordinates, $, document, window, dat*/
+/*global THREE, Coordinates, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit2/polygon-creation.js
+++ b/unit2/polygon-creation.js
@@ -7,7 +7,7 @@
 // to draw the polygon.
 // Radius of the polygon is 1. Center of the polygon is at 0, 0.
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE Coordinates $ document window*/
+/*global THREE, Coordinates, document, window*/
 
 var camera, scene, renderer;
 var windowScale;
@@ -64,7 +64,7 @@ function init() {
 
 }
 function showGrids() {
-  	// Background grid and axes. Grid step size is 1, axes cross at 0, 0
+	// Background grid and axes. Grid step size is 1, axes cross at 0, 0
 	Coordinates.drawGrid({size:100,scale:1,orientation:"z"});
 	Coordinates.drawAxes({axisLength:4,axisOrientation:"x",axisRadius:0.02});
 	Coordinates.drawAxes({axisLength:3,axisOrientation:"y",axisRadius:0.02});

--- a/unit2/polygon-location.js
+++ b/unit2/polygon-location.js
@@ -6,7 +6,7 @@
 // Return the mesh that defines the minimum number of triangles necessary
 // to draw the polygon.
 ////////////////////////////////////////////////////////////////////////////////
-/*global, THREE, Coordinates, $, document, window*/
+/*global THREE, Coordinates, document, window*/
 
 var camera, scene, renderer;
 var windowScale;

--- a/unit2/polygon-radius.js
+++ b/unit2/polygon-radius.js
@@ -7,7 +7,7 @@
 // Return the mesh that defines the minimum number of triangles necessary
 // to draw the polygon.
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE Coordinates $ document window*/
+/*global THREE, Coordinates, document, window*/
 
 var camera, scene, renderer;
 var windowScale;
@@ -68,7 +68,7 @@ function init() {
 	
 }
 function showGrids() {
-  	// Background grid and axes. Grid step size is 1, axes cross at 0, 0
+	// Background grid and axes. Grid step size is 1, axes cross at 0, 0
 	Coordinates.drawGrid({size:100,scale:1,orientation:"z"});
 	Coordinates.drawAxes({axisLength:4,axisOrientation:"x",axisRadius:0.02});
 	Coordinates.drawAxes({axisLength:3,axisOrientation:"y",axisRadius:0.02});

--- a/unit2/triangle-mesh.js
+++ b/unit2/triangle-mesh.js
@@ -5,7 +5,7 @@
 // for the square and returns a geometry object (THREE.Geometry())            //
 // that defines a square at the provided coordinates.                         //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE Coordinates $ document window*/
+/*global THREE, Coordinates, document, window*/
 
 var camera, scene, renderer;
 var windowScale;

--- a/unit2/vertex-order.js
+++ b/unit2/vertex-order.js
@@ -4,7 +4,7 @@
 // Check the function someObject()                                            //
 // and correct the code that starts at line 17.                               //
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE, Coordinates, $, document, window*/
+/*global THREE, Coordinates, document, window*/
 
 var camera, scene, renderer;
 var windowScale;

--- a/unit3/diffuse-material.js
+++ b/unit3/diffuse-material.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-/*global THREE, requestAnimationFrame, Detector, Stats, dat window document Coordinates*/
+/*global THREE, window, document, Coordinates*/
 var camera, scene, renderer;
 var cameraControls;
 var clock = new THREE.Clock();
@@ -9,7 +9,6 @@ var ambientLight, light;
 function init() {
 	var canvasWidth = window.innerWidth;
 	var canvasHeight = window.innerHeight;
-	var canvasRatio = canvasWidth / canvasHeight;
 
 	// CAMERA
 
@@ -48,7 +47,6 @@ function createBall() {
 function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
-	scene.add( camera );
 
 	// LIGHTS
 	scene.add( ambientLight );

--- a/unit3/smooth-lambert.js
+++ b/unit3/smooth-lambert.js
@@ -9,7 +9,6 @@ var ambientLight, light;
 function init() {
 	var canvasWidth = window.innerWidth;
 	var canvasHeight = window.innerHeight;
-	var canvasRatio = canvasWidth / canvasHeight;
 
 	// CAMERA
 
@@ -54,7 +53,6 @@ function createBall() {
 function fillScene() {
 	scene = new THREE.Scene();
 	scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
-	scene.add( camera );
 
 	// LIGHTS
 	scene.add( ambientLight );

--- a/unit4/unit4-axis_angle_exercise.js
+++ b/unit4/unit4-axis_angle_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit4/unit4-clock_exercise.js
+++ b/unit4/unit4-clock_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit4/unit4-flower_exercise.js
+++ b/unit4/unit4-flower_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit4/unit4-rotation_exercise.js
+++ b/unit4/unit4-rotation_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit4/unit4-scale_exercise.js
+++ b/unit4/unit4-scale_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit4/unit4-snowman_exercise.js
+++ b/unit4/unit4-snowman_exercise.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE Coordinates $ document window dat*/
+/*global THREE, Coordinates, $, document, window, dat*/
 
 var camera, scene, renderer;
 var cameraControls, effectController;

--- a/unit5/unit5-db_geom_exercise.js
+++ b/unit5/unit5-db_geom_exercise.js
@@ -1,6 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
-/*global THREE */
+/*global THREE, document, window*/
+
 var camera, scene, renderer;
 var cameraControls;
 
@@ -211,7 +212,6 @@ function fillScene() {
 function init() {
 	var canvasWidth = window.innerWidth;
 	var canvasHeight = window.innerHeight;
-	var canvasRatio = canvasWidth / canvasHeight;
 
 	// RENDERER
 	renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -248,8 +248,3 @@ function render() {
 
 init();
 animate();
-$("body").keydown(function(event) {
-	if (event.which === 80) {
-		takeScreenshot();
-	}
-});

--- a/unit5/unit5-ps_helix_exercise.js
+++ b/unit5/unit5-ps_helix_exercise.js
@@ -116,7 +116,7 @@ function fillScene() {
 //   tubularSegments - tessellation around equator of each tube
 //   height - height to extend, from *center* of tube ends along Y axis
 //   arc - how many times to go around the Y axis; currently just an integer
-//	 clockwise - if true, go counterclockwise up the axis
+//   clockwise - if true, go counterclockwise up the axis
 function createHelix( material, radius, tube, radialSegments, tubularSegments, height, arc, clockwise )
 {
 	// defaults
@@ -138,8 +138,8 @@ function createHelix( material, radius, tube, radialSegments, tubularSegments, h
 	{
 		// going from X to Z axis
 		top.set( radius * Math.cos( i * 2*Math.PI / radialSegments ),
-		    height * (i/(arc*radialSegments)) - height/2,
-		    sine_sign * radius * Math.sin( i * 2*Math.PI / radialSegments ) );
+			height * (i/(arc*radialSegments)) - height/2,
+			sine_sign * radius * Math.sin( i * 2*Math.PI / radialSegments ) );
 
 		var sphere = new THREE.Mesh( sphGeom, material );
 		sphere.position.copy( top );


### PR DESCRIPTION
Lots of little cleanups, making JSHint work well in standalone. Removed
all scene.add( camera ) calls, as these are no longer needed in
three.js.
