### PR TITLE
simpler and more reliable mouseX/Y code

### DIFF
--- a/demo/unit10-picking.js
+++ b/demo/unit10-picking.js
@@ -104,14 +104,31 @@ function onDocumentMouseDown( event ) {
 
 	// Annoying nested window code: need to subtract offsets for nested windows.
 	// This is not needed if you have just a single window filling the browser
-	var node = event.srcElement;
-	var mouseX = event.clientX - node.offsetLeft;
-	var mouseY = event.clientY - node.offsetTop;
+	// var node = event.srcElement;
+	// var mouseX = event.clientX - node.offsetLeft;
+	// var mouseY = event.clientY - node.offsetTop;
+
+
+    // getBoundingClientRect()
+    //   givest the element's position relative to the browser's visile viewport.
+    // clientX/Y 
+    //   gives the mouse position relative to the browser's visible viewport.
+    //
+    // we then just have to find the difference between the two 
+    // to get the mouse position in "canvas-space"
+	var canvasPosition = renderer.domElement.getBoundingClientRect();
+	var mouseX = event.clientX - canvasPosition.left;
+	var mouseY = event.clientY - canvasPosition.top;
+
+	// console.log(canvasPosition.left,canvasPosition.top);
+	// console.log(mouseX,mouseY);
+
+	/*
 	while (node.offsetParent){
 		node = node.offsetParent;
 		mouseX -= node.offsetLeft;
 		mouseY -= node.offsetTop;
-	}
+	}*/
 
 	/* the old way */
 	/*


### PR DESCRIPTION
In unit10-picking, the mouse projection wasn't right if your page was scrolled.

Since the canvas was of size window.innerWidth,window.innerHeight and there was an extra menu on top to selection demo and exercises, scrollbar could appear.

Another solution would be to resize the canvas automagically on window.onresize() and somehow get the height of this menu section, but it seems like a pain (without using jQuery).
To me that's more the mouseX/Y code that was a wrong.

My change was tested on chrome and firefox.
